### PR TITLE
WIP: propagate inputPath changes to wrapped plugins

### DIFF
--- a/tools/broccoli/broccoli-dest-copy.ts
+++ b/tools/broccoli/broccoli-dest-copy.ts
@@ -11,7 +11,7 @@ import {wrapDiffingPlugin, DiffingBroccoliPlugin, DiffResult} from './diffing-br
  * and tees a copy to the given path outside the tmp dir.
  */
 class DestCopy implements DiffingBroccoliPlugin {
-  constructor(private inputPath, private cachePath, private outputRoot: string) {}
+  constructor(public inputPath, private cachePath, private outputRoot: string) {}
 
 
   rebuild(treeDiff: DiffResult) {

--- a/tools/broccoli/broccoli-typescript.ts
+++ b/tools/broccoli/broccoli-typescript.ts
@@ -35,14 +35,22 @@ class DiffingTSCompiler implements DiffingBroccoliPlugin {
   static includeExtensions = ['.ts'];
   static excludeExtensions = ['.d.ts'];
 
-  constructor(public inputPath: string, public cachePath: string, public options) {
+  private _inputPath: string = null;
+  get inputPath() { return this._inputPath; }
+  set inputPath(path: string) {
+    if (path === this._inputPath) return;
+    this._inputPath = path;
+    this.tsServiceHost = new CustomLanguageServiceHost(this.tsOpts, this.rootFilePaths,
+                                                       this.fileRegistry, path);
+    this.tsService = ts.createLanguageService(this.tsServiceHost, ts.createDocumentRegistry());
+  }
+
+  constructor(inputPath: string, public cachePath: string, public options) {
     this.tsOpts = Object.create(options);
     this.tsOpts.outDir = this.cachePath;
     this.tsOpts.target = (<any>ts).ScriptTarget[options.target];
     this.rootFilePaths = options.rootFilePaths ? options.rootFilePaths.splice(0) : [];
-    this.tsServiceHost = new CustomLanguageServiceHost(this.tsOpts, this.rootFilePaths,
-                                                       this.fileRegistry, this.inputPath);
-    this.tsService = ts.createLanguageService(this.tsServiceHost, ts.createDocumentRegistry());
+    this.inputPath = inputPath;
   }
 
 

--- a/tools/broccoli/diffing-broccoli-plugin.ts
+++ b/tools/broccoli/diffing-broccoli-plugin.ts
@@ -29,6 +29,7 @@ export function wrapDiffingPlugin(pluginClass): DiffingPluginWrapperFactory {
 export interface DiffingBroccoliPlugin {
   rebuild(diff: DiffResult): (Promise<any>| void);
   cleanup ? () : void;
+  inputPath?: string;
 }
 
 
@@ -45,9 +46,15 @@ class DiffingPluginWrapper implements BroccoliTree {
   description = null;
 
   // props monkey-patched by broccoli builder:
-  inputPath = null;
+  _inputPath = null;
+  _inputPaths = null;
   cachePath = null;
   outputPath = null;
+  get inputPath() { return this._inputPath; }
+  set inputPath(path) {
+    this._inputPath = path;
+    if (this.initialized) this.wrappedPlugin.inputPath = path;
+  }
 
   constructor(private pluginClass, private wrappedPluginArguments) {
     if (Array.isArray(wrappedPluginArguments[0])) {

--- a/tools/broccoli/tree-differ.ts
+++ b/tools/broccoli/tree-differ.ts
@@ -65,8 +65,9 @@ export class TreeDiffer {
         if (!(this.include && !absolutePath.match(this.include)) &&
             !(this.exclude && absolutePath.match(this.exclude))) {
           result.filesChecked++;
-          if (this.isFileDirty(absolutePath, pathStat)) {
-            result.changedPaths.push(path.relative(this.rootPath, absolutePath));
+          let relativePath = path.relative(this.rootPath, absolutePath);
+          if (this.isFileDirty(relativePath, pathStat)) {
+            result.changedPaths.push(relativePath);
           }
         }
       }
@@ -96,11 +97,10 @@ export class TreeDiffer {
 
 
   private detectDeletionsAndUpdateFingerprints(result: DiffResult) {
-    for (let absolutePath in this.fingerprints) {
-      if (!(this.include && !absolutePath.match(this.include)) &&
-          !(this.exclude && absolutePath.match(this.exclude))) {
-        if (this.fingerprints[absolutePath] !== null) {
-          let relativePath = path.relative(this.rootPath, absolutePath);
+    for (let relativePath in this.fingerprints) {
+      if (!(this.include && !relativePath.match(this.include)) &&
+          !(this.exclude && relativePath.match(this.exclude))) {
+        if (this.fingerprints[relativePath] !== null) {
           result.removedPaths.push(relativePath);
         }
       }


### PR DESCRIPTION
This is rebased ontop of master, so the diff is probably messy --- this seems to work well locally, though.

**edit** not rebased ontop of master anymore
